### PR TITLE
123

### DIFF
--- a/src/main/java/dogapi/CachingBreedFetcher.java
+++ b/src/main/java/dogapi/CachingBreedFetcher.java
@@ -30,6 +30,9 @@ public class CachingBreedFetcher implements BreedFetcher {
         callsMade++;
         List<String> subs = fetcher.getSubBreeds(breed);
         cache.put(breed, subs);
+
+
+
         return subs;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Insert three blank lines before the return statement in getSubBreeds for readability